### PR TITLE
fix OCR1A init value

### DIFF
--- a/src/Volume.cpp
+++ b/src/Volume.cpp
@@ -75,7 +75,7 @@ void Volume::begin() {
   TCCR1B = 0; // same for TCCR1B
   TCNT1  = 0; // initialize counter value to 0
   // set compare match register for 10000 Hz increments
-  OCR1A = F_CPU / (1 * 10000) - 1;
+  OCR1A = F_CPU / (2 * 1 * 10000) - 1;
   // turn on CTC mode
   TCCR1B |= (1 << WGM12);
   // Set CS12, CS11 and CS10 bits for 1 prescaler


### PR DESCRIPTION
In case of CTC mode, f_oc = (f_clock/(2 * N * (1 + OCR));